### PR TITLE
Esc 44 back add user id to like field

### DIFF
--- a/contorollers/feed.js
+++ b/contorollers/feed.js
@@ -43,3 +43,27 @@ exports.getFeed = async (req, res, next) => {
     next(err);
   }
 };
+
+exports.addLikeUser = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    const { userId } = req.body;
+
+    if (!mongoose.isValidObjectId(id)) {
+      next(createError(400, "Invalid feed id"));
+    }
+
+    if (!mongoose.isValidObjectId(userId)) {
+      next(createError(400, "Invalid user id"));
+    }
+
+    const feed = await feedService.addLikeUser({ id, userId });
+
+    res.json({
+      result: resultMsg.ok,
+      data: feed,
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/routes/feed.js
+++ b/routes/feed.js
@@ -33,6 +33,8 @@ router.post("/img", upload.single("img"), (req, res) => {
   res.json({ url, originalUrl: req.file.location });
 });
 
+router.put("/:id/like", feedController.addLikeUser);
+
 router.get("/:id", feedController.getFeed);
 
 module.exports = router;

--- a/services/feed.js
+++ b/services/feed.js
@@ -40,3 +40,14 @@ exports.getFeed = async (id) => {
     })
     .exec();
 };
+
+exports.addLikeUser = async (option) => {
+  option.id = mongoose.Types.ObjectId(option.id);
+  option.userId = mongoose.Types.ObjectId(option.userId);
+
+  return await Feed.findByIdAndUpdate(
+    option.id,
+    { $addToSet: { like: option.userId } },
+    { safe: true, upsert: true, new: true },
+  ).exec();
+};


### PR DESCRIPTION
# [ESC-44] Add user id to like field

## 노션 칸반 링크

- [[Back]Add user id to like field](https://earth-saving-cleaner.atlassian.net/browse/ESC-44)

## 카드에서 구현 혹은 해결하려는 내용
- like에 userId 추가하기

## 테스트 방법
- [postman link](https://universal-shadow-625315.postman.co/workspace/esc~cf810b75-7b96-479f-a254-e41f57f664cb/request/10737586-80c3b4e2-bbab-4cad-ad31-57a32f62238e)
- postman access 안될 시
  - PUT
  - `http://localhost:4000/feed/61fe4298a5010f7ed7e75f7a/like`
  - Body에 raw-JSON 설정 후 `{ "userId": "61fe405e1a04b2694da83266" }` 추가
  - Send
 
## 기타 사항
- like 필드 array는 같은 id의 User가 중복으로 들어가면 안 되므로 $addToSet을 사용


[ESC-44]: https://earth-saving-cleaner.atlassian.net/browse/ESC-44?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ