### PR TITLE
Esc 54 [back] add comments to a feed

### DIFF
--- a/app.js
+++ b/app.js
@@ -40,7 +40,7 @@ app.use((err, req, res, next) => {
   res.locals.error = req.app.get("env") === "development" ? err : {};
 
   const code = err.status || 500;
-  const message = err.message || resultMsg.serverError;
+  const message = code === 500 ? resultMsg.serverError : err.message;
 
   res.status(err.status || 500);
   res.json({ code, result: resultMsg.fail, message });

--- a/contorollers/feed.js
+++ b/contorollers/feed.js
@@ -49,6 +49,29 @@ exports.getFeed = async (req, res, next) => {
   }
 };
 
+exports.createComment = async (req, res, next) => {
+  try {
+    const { id } = req.params;
+    const { userId, content } = req.body;
+
+    if (!mongoose.isValidObjectId(id)) {
+      next(createError(400, "Invalid feed id"));
+    }
+
+    if (!mongoose.isValidObjectId(userId)) {
+      next(createError(400, "Invalid user id"));
+    }
+
+    const comments = await feedService.createComment({ id, userId, content });
+    res.json({
+      result: resultMsg.ok,
+      data: comments,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
 const validateLimit = (limit) => {
   const LIMIT = 30;
 

--- a/contorollers/feed.js
+++ b/contorollers/feed.js
@@ -1,12 +1,20 @@
+const mongoose = require("mongoose");
+const createError = require("http-errors");
+
 const feedService = require("../services/feed");
 const { resultMsg } = require("../constants");
 
 exports.getFeeds = async (req, res, next) => {
   try {
     const { id, limit } = req.query;
+
+    if (id && !mongoose.isValidObjectId(id)) {
+      next(createError(400, "Invalid feed last feed id"));
+    }
+
     const option = {
       lastId: id,
-      limit: limit || 30,
+      limit: validateLimit(limit),
     };
 
     const feeds = await feedService.getFeeds(option);
@@ -20,4 +28,18 @@ exports.getFeeds = async (req, res, next) => {
   } catch (error) {
     next(error);
   }
+};
+
+const validateLimit = (limit) => {
+  const LIMIT = 30;
+
+  if (typeof limit !== "number" || typeof limit !== "string") {
+    return LIMIT;
+  }
+
+  if (limit <= 0) {
+    return LIMIT;
+  }
+
+  return Number(limit);
 };

--- a/middlewares/validator.js
+++ b/middlewares/validator.js
@@ -1,0 +1,34 @@
+const { body, validationResult } = require("express-validator");
+
+const { resultMsg } = require("../constants");
+
+const commentValidationRules = () => {
+  return [
+    body("userId").not().isEmpty().withMessage("User id is empty").isString().withMessage("User id should be string"),
+    body("content")
+      .not()
+      .isEmpty()
+      .withMessage("Comment content is empty")
+      .isString()
+      .withMessage("Comment content should be string"),
+  ];
+};
+
+const validate = (req, res, next) => {
+  const errors = validationResult(req);
+  console.error(errors);
+
+  if (errors.isEmpty()) {
+    return next();
+  }
+
+  let errorMessages = "";
+  errors.array().map((err) => (errorMessages += `${err.msg}. `));
+
+  res.status(400).json({ code: 400, result: resultMsg.fail, message: resultMsg.badRequest });
+};
+
+module.exports = {
+  commentValidationRules,
+  validate,
+};

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "cors": "^2.8.5",
     "dotenv": "^15.0.0",
     "express": "^4.17.2",
+    "express-validator": "^6.14.0",
     "http-errors": "^2.0.0",
     "jsonwebtoken": "^8.5.1",
     "mongoose": "^6.1.10",

--- a/routes/feed.js
+++ b/routes/feed.js
@@ -6,6 +6,7 @@ const AWS = require("aws-sdk");
 const multerS3 = require("multer-s3");
 
 const feedController = require("../contorollers/feed");
+const { commentValidationRules, validate } = require("../middlewares/validator");
 
 const router = express.Router();
 
@@ -32,6 +33,8 @@ router.post("/img", upload.single("img"), (req, res) => {
   const url = originalUrl.replace(/\/original\//, "/thumb/");
   res.json({ url, originalUrl: req.file.location });
 });
+
+router.post("/:id/comment", commentValidationRules(), validate, feedController.createComment);
 
 router.get("/:id", feedController.getFeed);
 

--- a/services/feed.js
+++ b/services/feed.js
@@ -1,6 +1,7 @@
 const mongoose = require("mongoose");
 
 const Feed = require("../models/Feed");
+const Comment = require("../models/Comment");
 
 exports.getFeeds = async (option) => {
   const { lastId, limit } = option;
@@ -39,4 +40,20 @@ exports.getFeed = async (id) => {
       },
     })
     .exec();
+};
+
+exports.createComment = async (option) => {
+  option.id = mongoose.Types.ObjectId(option.id);
+  option.userId = mongoose.Types.ObjectId(option.userId);
+
+  const comment = await Comment.create({ author: option.userId, content: option.content });
+  const feedComments = await Feed.findByIdAndUpdate(
+    option.id,
+    { $push: { comment: comment._id } },
+    { safe: true, upsert: true, new: true, populate: { path: "comment" } },
+  )
+    .select("comment")
+    .exec();
+
+  return feedComments;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1709,6 +1709,14 @@ expect@^27.4.6:
     jest-matcher-utils "^27.4.6"
     jest-message-util "^27.4.6"
 
+express-validator@^6.14.0:
+  version "6.14.0"
+  resolved "https://registry.yarnpkg.com/express-validator/-/express-validator-6.14.0.tgz#8ee7a32bf1ffcf2573db5f17c9cad279698e5d41"
+  integrity sha512-ZWHJfnRgePp3FKRSKMtnZVnD1s8ZchWD+jSl7UMseGIqhweCo1Z9916/xXBbJAa6PrA3pUZfkOvIsHZG4ZtIMw==
+  dependencies:
+    lodash "^4.17.21"
+    validator "^13.7.0"
+
 express@^4.17.2:
   version "4.17.2"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.2.tgz#c18369f265297319beed4e5558753cc8c1364cb3"
@@ -2906,7 +2914,7 @@ lodash.once@^4.0.0:
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
 
-lodash@^4.7.0:
+lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
# [Esc 54] Add comments to a feed

## 노션 칸반 링크
- [[Back]Add comments to a feed](https://earth-saving-cleaner.atlassian.net/browse/ESC-54)

## 카드에서 구현 혹은 해결하려는 내용
- 피드 댓글 추가
- express-validator 추가 후 유효성 검사

## 테스트 방법
- [Postman url](https://universal-shadow-625315.postman.co/workspace/esc~cf810b75-7b96-479f-a254-e41f57f664cb/request/10737586-ef43cb87-adeb-47d4-915b-af69c01e8c15)

- 위의 url 작동되지 않을 시, postman에서 `POST` 요청
  - `http://localhost:4000/feed/61fe4298a5010f7ed7e75f7a/comment`
  - Body - raw - JSON 설정 후 `{"userId": "61fe405e1a04b2694da83265", "content": "Hi"}` 입력
  - Send

## 기타 사항
- 고민이 되는 부분이 있었습니다. api를 호출하여 댓글 추가한 후 response body에 반환하는 데이터에 모든 피드 정보가 포함되지 않아도 될 것 같아서 해당 피드의 comment 정보만 리턴하도록 구현했습니다.