### PR TITLE
[Esc-70] back get feeds coordinate information

### DIFF
--- a/contorollers/location.js
+++ b/contorollers/location.js
@@ -4,14 +4,15 @@ const { resultMsg } = require("../constants");
 // [37.514035, 127.05151, 37.50188, 127.06708] -> Mock data nw.lat nw.lng se.lat se.lng
 exports.getFeedsLocation = async (req, res, next) => {
   try {
-    const { nwLat, nwLng, seLat, seLng } = req.query;
+    const { coordinates } = req.query;
+    const { nwLng, nwLat, seLng, seLat } = JSON.parse(coordinates);
 
     const polygonCoordinates = [
-      [Number(nwLng), Number(nwLat)],
-      [Number(seLng), Number(nwLat)],
-      [Number(seLng), Number(seLat)],
-      [Number(nwLng), Number(seLat)],
-      [Number(nwLng), Number(nwLat)],
+      [nwLng, nwLat],
+      [seLng, nwLat],
+      [seLng, seLat],
+      [nwLng, seLat],
+      [nwLng, nwLat],
     ];
 
     const feedInfo = await locationService.getFeedsLocation(polygonCoordinates);

--- a/contorollers/location.js
+++ b/contorollers/location.js
@@ -1,0 +1,26 @@
+const locationService = require("../services/feeds");
+const { resultMsg } = require("../constants");
+
+// [37.514035, 127.05151, 37.50188, 127.06708] -> Mock data nw.lat nw.lng se.lat se.lng
+exports.getFeedsLocation = async (req, res, next) => {
+  try {
+    const { nwLat, nwLng, seLat, seLng } = req.query;
+
+    const polygonCoordinates = [
+      [Number(nwLng), Number(nwLat)],
+      [Number(seLng), Number(nwLat)],
+      [Number(seLng), Number(seLat)],
+      [Number(nwLng), Number(seLat)],
+      [Number(nwLng), Number(nwLat)],
+    ];
+
+    const feedInfo = await locationService.getFeedsLocation(polygonCoordinates);
+
+    res.json({
+      result: resultMsg.ok,
+      feedInfo,
+    });
+  } catch (err) {
+    next(err);
+  }
+};

--- a/contorollers/location.js
+++ b/contorollers/location.js
@@ -5,14 +5,14 @@ const { resultMsg } = require("../constants");
 exports.getFeedsLocation = async (req, res, next) => {
   try {
     const { coordinates } = req.query;
-    const { nwLng, nwLat, seLng, seLat } = JSON.parse(coordinates);
+    const { NWlongitude, NWlatitude, SElongitude, SElatitude } = JSON.parse(coordinates);
 
     const polygonCoordinates = [
-      [nwLng, nwLat],
-      [seLng, nwLat],
-      [seLng, seLat],
-      [nwLng, seLat],
-      [nwLng, nwLat],
+      [NWlongitude, NWlatitude],
+      [SElongitude, NWlatitude],
+      [SElongitude, SElatitude],
+      [NWlongitude, SElatitude],
+      [NWlongitude, NWlatitude],
     ];
 
     const feedInfo = await locationService.getFeedsLocation(polygonCoordinates);

--- a/routes/feeds.js
+++ b/routes/feeds.js
@@ -1,0 +1,11 @@
+const express = require("express");
+const router = express.Router();
+
+const { getFeeds } = require("../contorollers/feed");
+const { getFeedsLocation } = require("../contorollers/location");
+
+router.get("/", getFeeds);
+
+router.get("/locations", getFeedsLocation);
+
+module.exports = router;

--- a/routes/feeds.js
+++ b/routes/feeds.js
@@ -5,7 +5,6 @@ const { getFeeds } = require("../contorollers/feed");
 const { getFeedsLocation } = require("../contorollers/location");
 
 router.get("/", getFeeds);
-
 router.get("/locations", getFeedsLocation);
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,8 +1,8 @@
 const express = require("express");
 
 const { getUser } = require("../contorollers/user");
-const { getFeeds } = require("../contorollers/feed");
 const feed = require("./feed");
+const feeds = require("./feeds");
 const user = require("./user");
 
 const User = require("../models/User");
@@ -13,7 +13,7 @@ const Plogging = require("../models/Plogging");
 const router = express.Router();
 
 router.use("/user", user);
-router.get("/feeds", getFeeds);
+router.use("/feeds", feeds);
 router.use("/feed", feed);
 
 module.exports = router;

--- a/services/feeds.js
+++ b/services/feeds.js
@@ -1,0 +1,29 @@
+const Feed = require("../models/Feed");
+
+exports.getFeedsLocation = async (coordinates) => {
+  return await Feed.aggregate([
+    {
+      $lookup: {
+        from: "geos",
+        localField: "location",
+        foreignField: "_id",
+        as: "location",
+      },
+    },
+    {
+      $match: {
+        location: {
+          $geoWithin: {
+            $geometry: {
+              type: "Polygon",
+              coordinates: [coordinates],
+            },
+          },
+        },
+      },
+    },
+    {
+      $project: { image: 1, coordinates: { $arrayElemAt: ["$location.coordinates", 0] }, cleaned: 1 },
+    },
+  ]);
+};


### PR DESCRIPTION
# [Esc-70] back get feeds coordinate information

## Jira 링크

- [Esc-70](https://earth-saving-cleaner.atlassian.net/jira/software/projects/ESC/boards/1?selectedIssue=ESC-70)

## 카드에서 구현 혹은 해결하려는 내용
- 클라이언트 화면에 보여지는 영역에 대해 feed 위치 정보 및 feed 정보 client에게 전달
- clean, image url, coordinates, feed id 값 전달

## 테스트 방법
- [Post man](https://universal-shadow-625315.postman.co/workspace/esc~cf810b75-7b96-479f-a254-e41f57f664cb/request/18992430-54ce3784-6498-4e49-9d48-f4ecd54fa946)
- 화면 꼭지점 영역을 mock데이터로 설정하고 진행함. postman -> param coordinates값
-  postman -> param coordinates: {"nwLat": 37.514035, "nwLng":127.05151, "seLat": 37.50188, "seLng": 127.06708} 설정
-  send
## 기타 사항
- Jira success response body 수정 like 제거 feedInfo 추가
- feedInfo(feedId, image, clean, coordinates)