### PR TITLE
Esc 37 Create feed

### DIFF
--- a/contorollers/feed.js
+++ b/contorollers/feed.js
@@ -2,6 +2,7 @@ const mongoose = require("mongoose");
 const createError = require("http-errors");
 
 const feedService = require("../services/feed");
+const geoService = require("../services/geo");
 const { resultMsg } = require("../constants");
 
 exports.getFeeds = async (req, res, next) => {
@@ -93,6 +94,26 @@ exports.createComment = async (req, res, next) => {
     res.json({
       result: resultMsg.ok,
       data: comments,
+    });
+  } catch (err) {
+    next(err);
+  }
+};
+
+exports.createFeed = async (req, res, next) => {
+  try {
+    const { userId, pictureUrl, content, location } = req.body;
+
+    if (!mongoose.isValidObjectId(userId)) {
+      next(createError(400, "Invalid user id"));
+    }
+
+    const geo = await geoService.createGeo({ location });
+    const feed = await feedService.createFeed({ userId, pictureUrl, content, location: geo._id });
+
+    res.json({
+      result: resultMsg.ok,
+      data: feed,
     });
   } catch (err) {
     next(err);

--- a/middlewares/validator.js
+++ b/middlewares/validator.js
@@ -14,6 +14,61 @@ const commentValidationRules = () => {
   ];
 };
 
+const feedValidationRules = () => {
+  return [
+    body("userId").not().isEmpty().withMessage("User id is empty").isString().withMessage("User id should be string"),
+    body("pictureUrl")
+      .not()
+      .isEmpty()
+      .withMessage("pictureUrl is empty")
+      .isArray()
+      .withMessage("pictureUrl should be array"),
+    body("pictureUrl")
+      .custom((urls) => {
+        for (const url of urls) {
+          return typeof url === "string";
+        }
+      })
+      .withMessage("pictureUrl should contain string values"),
+    body("content")
+      .custom((content) => {
+        if (content.length === 0) {
+          return true;
+        }
+
+        if (typeof content === "string") {
+          return true;
+        }
+
+        return false;
+      })
+      .withMessage("Content should be string if content is not empty"),
+    body("location")
+      .not()
+      .isEmpty()
+      .withMessage("Location is empty")
+      .isArray()
+      .withMessage("pictureUrl should be array"),
+    body("location")
+      .custom(([longitude, latitude]) => {
+        if (typeof longitude !== "number" || typeof latitude !== "number") {
+          return false;
+        }
+
+        if (longitude > 180 || longitude < -180) {
+          return false;
+        }
+
+        if (latitude > 90 || latitude < -90) {
+          return false;
+        }
+
+        return true;
+      })
+      .withMessage("location is not valid"),
+  ];
+};
+
 const validate = (req, res, next) => {
   const errors = validationResult(req);
   console.error(errors);
@@ -30,5 +85,6 @@ const validate = (req, res, next) => {
 
 module.exports = {
   commentValidationRules,
+  feedValidationRules,
   validate,
 };

--- a/routes/feed.js
+++ b/routes/feed.js
@@ -6,7 +6,7 @@ const AWS = require("aws-sdk");
 const multerS3 = require("multer-s3");
 
 const feedController = require("../contorollers/feed");
-const { commentValidationRules, validate } = require("../middlewares/validator");
+const { commentValidationRules, feedValidationRules, validate } = require("../middlewares/validator");
 
 const router = express.Router();
 
@@ -35,8 +35,8 @@ router.post("/img", upload.single("img"), (req, res) => {
 });
 
 router.post("/:id/comment", commentValidationRules(), validate, feedController.createComment);
+router.post("/", feedValidationRules(), validate, feedController.createFeed);
 router.put("/:id/like", feedController.addLikeUser);
-
 router.get("/:id", feedController.getFeed);
 
 module.exports = router;

--- a/routes/index.js
+++ b/routes/index.js
@@ -13,7 +13,7 @@ const Plogging = require("../models/Plogging");
 const router = express.Router();
 
 router.use("/user", user);
-router.get("/feeds", getFeeds);
 router.use("/feed", feed);
+router.get("/feeds", getFeeds);
 
 module.exports = router;

--- a/services/feed.js
+++ b/services/feed.js
@@ -58,6 +58,15 @@ exports.createComment = async (option) => {
   return feedComments;
 };
 
+exports.createFeed = async ({ userId, pictureUrl, content, location }) => {
+  return await Feed.create({
+    author: userId,
+    content,
+    image: pictureUrl,
+    location,
+  });
+};
+
 exports.addLikeUser = async (option) => {
   option.id = mongoose.Types.ObjectId(option.id);
   option.userId = mongoose.Types.ObjectId(option.userId);

--- a/services/geo.js
+++ b/services/geo.js
@@ -1,0 +1,10 @@
+const mongoose = require("mongoose");
+
+const Geo = require("../models/Geo");
+
+exports.createGeo = async ({ location }) => {
+  return await Geo.create({
+    type: "Point",
+    coordinates: location,
+  });
+};


### PR DESCRIPTION
# [Esc 37] Create feed

## jira 칸반 링크

- [[Back] Create feed](https://earth-saving-cleaner.atlassian.net/browse/ESC-37)

## 카드에서 구현 혹은 해결하려는 내용
- 피드 등록 api 추가
- validation 추가

## 테스트 방법
- [postman url](https://universal-shadow-625315.postman.co/workspace/esc~cf810b75-7b96-479f-a254-e41f57f664cb/request/10737586-39224de8-8d55-437f-978c-781708b75028)
- url 접근 불가한 경우
  - go to postman
  - set POST method
  - set `http://localhost:4000/feed`
  - set Body - raw - JSON
    - type sample body
    ```
     {
      "userId": "61fe3f53a5010f7ed7e75f4d",
      "pictureUrl": ["image url", "url2"],
      "content": "help",
      "location": [-104.9903, 39.7392]
    }
    ```

## 기타 사항
- validation을 추가 시 데이터가 array일 때, array type 체크와 함께 각 원소의 type도 체크할 수 있게 도와주는 메서드가 있을 것 같은데 찾지 못하여서 우선 custom으로 작성해두었습니다. (사진 url 유효성 검사)
- empty인 null 데이터를 허용하고 동시에 data가 있다면 stinrg만 허용해주는 메서드도 찾아보았는데 해결되지 않아서 custom으로 작성해두었습니다. (content 유효성 검사 => content는 비어있어도 되므로)
- validation을 추가할 때 위의 두가지를 조금 더 깔끔하게 작성할 수 있을 것 같아서 서치해보았지만 아직 적절한 메서드를 찾지 못하여서 아시는 정보가 있다면 코멘트 주시면 감사하겠습니다🙇‍♀️
