### PR TITLE
[ESC-134] update: add level, score in signup response

### DIFF
--- a/contorollers/signup.js
+++ b/contorollers/signup.js
@@ -6,12 +6,13 @@ const { resultMsg } = require("../constants");
 exports.signup = async (req, res, next) => {
   const { googleToken, nickname } = req.body;
 
-  const badRequestResult = {
-    result: resultMsg.fail,
-    message: resultMsg.badRequest,
-  };
-
-  if (!googleToken || !nickname) return res.status(400).json(badRequestResult);
+  if (!googleToken || !nickname) {
+    res.status(400).json({
+      result: resultMsg.fail,
+      message: resultMsg.badRequest,
+    });
+    return;
+  }
 
   try {
     const verifiedUser = await jwt.verifyGoogleToken(googleToken);
@@ -31,7 +32,7 @@ exports.signup = async (req, res, next) => {
       const newUser = await User.create({ email, nickname, profileImage: picture });
       const jwtToken = await jwt.sign(newUser._id, email);
 
-      return res.status(201).json({
+      res.status(201).json({
         result: resultMsg.ok,
         message: resultMsg.created,
         token: jwtToken.accessToken,
@@ -39,6 +40,8 @@ exports.signup = async (req, res, next) => {
         id: newUser._id,
         profileImage: newUser.profileImage,
         nickname: newUser.nickname,
+        level: newUser.level,
+        score: newUser.score,
       });
     } catch (err) {
       console.error(err);


### PR DESCRIPTION
# [ESC-134] Update signup response data
제목 예시: [17] 메인페이지 UI
## 노션 칸반 링크

- [[ESC-134] Update signup response data](https://earth-saving-cleaner.atlassian.net/browse/ESC-134)

## 카드에서 구현 혹은 해결하려는 내용
- signup response에 level, score 추가


[ESC-134]: https://earth-saving-cleaner.atlassian.net/browse/ESC-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ESC-134]: https://earth-saving-cleaner.atlassian.net/browse/ESC-134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ