### PR TITLE
[ESC-135]fix: addCleanTrue db query filter

### DIFF
--- a/services/feed.js
+++ b/services/feed.js
@@ -85,5 +85,5 @@ exports.addLikeUser = async (option) => {
 };
 
 exports.addCleanTrue = async (id) => {
-  return await Feed.findOneAndUpdate(id, { $set: { cleaned: true } }, { new: true });
+  return await Feed.findOneAndUpdate({ _id: id }, { $set: { cleaned: true } }, { new: true });
 };


### PR DESCRIPTION
# [ESC-135] change addCleanTrue db query filter

## Jira 링크

- [ESC-135](https://earth-saving-cleaner.atlassian.net/browse/ESC-135)

## 카드에서 구현 혹은 해결하려는 내용
- feed를 필터하는 부분에서 오류 발생

## 테스트 방법
- client plogging test
-
## 기타 사항
- notion ploblem solve에 추가
- [notion](https://www.notion.so/vanillacoding/Back-mongodb-error-findOneAndUpdate-ff0cd260332543fbbcde4f3df6faf15e)

[ESC-135]: https://earth-saving-cleaner.atlassian.net/browse/ESC-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ