### PR TITLE
[ESC 166] Add total count to getFeeds

### DIFF
--- a/contorollers/feed.js
+++ b/contorollers/feed.js
@@ -18,11 +18,13 @@ exports.getFeeds = async (req, res, next) => {
       limit: validateLimit(limit),
     };
 
+    const total = await feedService.getFeedTotalCount();
     const feeds = await feedService.getFeeds(option);
     const result = {
       result: resultMsg.ok,
       lastId: feeds[feeds.length - 1]._id,
       data: feeds,
+      total,
     };
 
     res.json(result);

--- a/services/feed.js
+++ b/services/feed.js
@@ -3,6 +3,10 @@ const mongoose = require("mongoose");
 const Feed = require("../models/Feed");
 const Comment = require("../models/Comment");
 
+exports.getFeedTotalCount = async () => {
+  return await Feed.countDocuments();
+};
+
 exports.getFeeds = async (option) => {
   const { lastId, limit } = option;
   console.log("lastId =====>", lastId);


### PR DESCRIPTION
# [ESC 166] update infinite scroll paging logic

## Jira 칸반 링크

- [Back-update infinite scroll paging logic](https://earth-saving-cleaner.atlassian.net/browse/ESC-166)

## 카드에서 구현 혹은 해결하려는 내용
- 피드의 총 갯수를 리턴하는 데이터 추가

## 테스트 방법
- [postman test](https://universal-shadow-625315.postman.co/workspace/esc~cf810b75-7b96-479f-a254-e41f57f664cb/request/10737586-16c64ca0-7807-4789-8478-c03e2bb68325)

